### PR TITLE
Add switch statement for intensity profiles

### DIFF
--- a/QuasistaticBrownianThermalNoise/QuasistaticBrownianThermalNoise.cpp
+++ b/QuasistaticBrownianThermalNoise/QuasistaticBrownianThermalNoise.cpp
@@ -335,17 +335,7 @@ CylTransFunc::CylTransFunc(double coatThick, double halfCylThick):
 
     //The negative sign here is because Tzj should point in the -z 
     //direction, so the mirror is compressed, not stretched.
-    //myValue = -1.0 * F0 * exp(myValue/(r0*r0));
-    //myValue = -1.0 * F0 * exp(myValue/(r0*r0)) * ((4*p(1)*p(1)/(r0*r0)-2)*(4*p(1)*p(1)/(r0*r0)-2)-(4*p(0)*p(0)/(r0*r0)-2)*(4*p(0)*p(0)/(r0*r0)-2));
-
     //Normalize: e.g. Liu+ Eq. (2): if F0=F0, I'd better divide by pi*r0^2
-    //myValue /= M_PI * r0 * r0;
-    //myValue /= 8 * M_PI * r0 * r0;
-
-    //Set the Neuman value: values(0) = T_zx, values(1) = T_zy, values(2)=Tzz
-    //dim=3, so values(dim-1) = Tzz.
-    //Note: this assumes only the top of the cylinder has a pressure applied
-    //Dirichlet conditions elsewhere.
 
     int mWhichProfile = TEM00;
 
@@ -371,6 +361,11 @@ CylTransFunc::CylTransFunc(double coatThick, double halfCylThick):
       break;
     }
 
+    //Set the Neuman value: values(0) = T_zx, values(1) = T_zy, values(2)=Tzz
+    //dim=3, so values(dim-1) = Tzz.
+    //Note: this assumes only the top of the cylinder has a pressure applied
+    //Dirichlet conditions elsewhere.
+	  
     values(dim-1) = myValue;
     
   }

--- a/QuasistaticBrownianThermalNoise/QuasistaticBrownianThermalNoise.cpp
+++ b/QuasistaticBrownianThermalNoise/QuasistaticBrownianThermalNoise.cpp
@@ -345,16 +345,16 @@ CylTransFunc::CylTransFunc(double coatThick, double halfCylThick):
       myValue /= M_PI * r0 * r0;
       break;
     case(TEM02):
-      myValue = -1.0 * F0 * exp(myValue/(r0*r0)) * (4*p(1)*p(1)/(r0*r0)-2)*(4*p(1)*p(1)/(r0*r0)-2);
-      myValue /= 8 * M_PI * r0 * r0;
+      myValue = -1.0 * F0 * exp(myValue/(r0*r0)) * (4.0*p(1)*p(1)/(r0*r0)-2.0)*(4.0*p(1)*p(1)/(r0*r0)-2.0);
+      myValue /= 8.0 * M_PI * r0 * r0;
       break;
     case(TEM20):
-      myValue = -1.0 * F0 * exp(myValue/(r0*r0)) * (4*p(0)*p(0)/(r0*r0)-2)*(4*p(0)*p(0)/(r0*r0)-2);
-      myValue /= 8 * M_PI * r0 * r0;
+      myValue = -1.0 * F0 * exp(myValue/(r0*r0)) * (4.0*p(0)*p(0)/(r0*r0)-2.0)*(4.0*p(0)*p(0)/(r0*r0)-2.0);
+      myValue /= 8.0 * M_PI * r0 * r0;
       break;
     case(TEM02minus20):
-      myValue = -1.0 * F0 * exp(myValue/(r0*r0)) * ((4*p(1)*p(1)/(r0*r0)-2)*(4*p(1)*p(1)/(r0*r0)-2)-(4*p(0)*p(0)/(r0*r0)-2)*(4*p(0)*p(0)/(r0*r0)-2));
-      myValue /= 8 * M_PI * r0 * r0;
+      myValue = -1.0 * F0 * exp(myValue/(r0*r0)) * ((4.0*p(1)*p(1)/(r0*r0)-2.0)*(4.0*p(1)*p(1)/(r0*r0)-2.0)-(4.0*p(0)*p(0)/(r0*r0)-2.0)*(4.0*p(0)*p(0)/(r0*r0)-2.0));
+      myValue /= 8.0 * M_PI * r0 * r0;
       break;
     default:
       std::cout << "WARNING! Invalid profile string. Do not trust results!\n";
@@ -530,7 +530,7 @@ CylTransFunc::CylTransFunc(double coatThick, double halfCylThick):
               //4.68 based on Table I of Chalermsongsak+ (2015)
               //earlier versions of this code used 4.68
       
-    substrateheight = 25000/2.0;
+    substrateheight = 25000.0/2.0;
 
 
     //halflength = rad/8.+d/2.; //0.25 in + coating = total thickness


### PR DESCRIPTION
Add missing switch statement for loss angle
Decouple substrate height from cylinder radius

I know these should have been 3 separate commits, but hopefully still okay. Just starting to get more comfortable with git.

Code tested using previous default settings, except changing max cycles to 7. Here is the output from diff on the Energy files. If this is approved I will edit the README to reflect the new options.

```
diff new/Run/Energy.dat old/Run/Energy.dat 
12c12
< 3 0.014610113175338 0.014310571480188 0.00029954169514985 8.6873193203975e-18 6.2842860113827e-18 1.072202255395e-17
---
> 3 0.014610113175338 0.014310571480188 0.00029954169514985 8.6873193203976e-18 6.2842860113827e-18 1.072202255395e-17
15c15
< 6 0.014949195050855 0.014633241095824 0.00031595395503144 8.7847126579797e-18 6.4541521458798e-18 1.090079154949e-17
---
> 6 0.014949195050854 0.014633241095825 0.00031595395502971 8.78471265798e-18 6.4541521458621e-18 1.090079154948e-17
```